### PR TITLE
Allow IO in custom pandoc readers/writers

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,8 @@
 # Changelog for sitepipe-shake
 
+## 0.2.0.0
+- Allow IO in `makePandocReader` and `makePandocWriter` to allow use of complex filters, etc.
+
 ## 0.1.1.0
 - Add gfm markdown options on writer extensions
     - this should allow pandoc to auto-generate id's on header tags

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                slick
-version:             0.1.1.0
+version:             0.2.0.0
 github:              "ChrisPenner/slick"
 license:             BSD3
 author:              "Chris Penner"

--- a/slick.cabal
+++ b/slick.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 82e242baaf6e23856eb332b4dea2777d8e59e45bf7bd685b1ab9b5adf58d0607
+-- hash: 3cc544477064cc4c1a83dee37ce64b9559692a238162f8704a62c1fb10265bed
 
 name:           slick
-version:        0.1.1.0
+version:        0.2.0.0
 description:    Please see the README on GitHub at <https://github.com/ChrisPenner/slick#readme>
 homepage:       https://github.com/ChrisPenner/slick#readme
 bug-reports:    https://github.com/ChrisPenner/slick/issues

--- a/src/Slick.hs
+++ b/src/Slick.hs
@@ -15,6 +15,8 @@ module Slick
   , makePandocReader'
   , loadUsing
   , loadUsing'
+  , markdownOptions
+  , html5Options
 
   -- ** Aeson
   , convert

--- a/src/Slick/Pandoc.hs
+++ b/src/Slick/Pandoc.hs
@@ -8,6 +8,8 @@ module Slick.Pandoc
   , loadUsing
   , loadUsing'
   , convert
+  , html5Options
+  , markdownOptions
   , PandocReader
   , PandocWriter
   ) where
@@ -27,14 +29,19 @@ markdownOptions :: ReaderOptions
 markdownOptions = def { readerExtensions = exts }
  where
   exts = mconcat
-    [extensionsFromList [Ext_yaml_metadata_block], githubMarkdownExtensions]
+    [ extensionsFromList
+      [ Ext_yaml_metadata_block
+      , Ext_fenced_code_attributes
+      , Ext_auto_identifiers
+      ]
+    , githubMarkdownExtensions
+    ]
 
 -- | Reasonable options for rendering to HTML
 html5Options :: WriterOptions
-html5Options = def
-  { writerHighlightStyle = Just tango
-  , writerExtensions = writerExtensions def `mappend` githubMarkdownExtensions
-  }
+html5Options = def { writerHighlightStyle = Just tango
+                   , writerExtensions     = writerExtensions def
+                   }
 
 -- | Handle possible pandoc failure within the Action Monad
 unPandocM :: PandocIO a -> Action a

--- a/src/Slick/Pandoc.hs
+++ b/src/Slick/Pandoc.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Slick.Pandoc
@@ -38,8 +37,10 @@ html5Options = def
   }
 
 -- | Handle possible pandoc failure within the Action Monad
-unPandocM :: PandocPure a -> Action a
-unPandocM = either (fail . show) return . runPure
+unPandocM :: PandocIO a -> Action a
+unPandocM p = do
+  result <- liftIO $ runIO p
+  either (fail . show) return result
 
 -- | Convert markdown text into a 'Value';
 -- The 'Value'  has a "content" key containing rendered HTML
@@ -52,9 +53,9 @@ markdownToHTML =
 markdownToHTML' :: (FromJSON a) => T.Text -> Action a
 markdownToHTML' = markdownToHTML >=> convert
 
-type PandocReader textType = textType -> PandocPure Pandoc
+type PandocReader textType = textType -> PandocIO Pandoc
 
-type PandocWriter = Pandoc -> PandocPure T.Text
+type PandocWriter = Pandoc -> PandocIO T.Text
 
 -- | Given a reader from 'Text.Pandoc.Readers' this creates a loader which
 -- given the source document will read its metadata into a 'Value'


### PR DESCRIPTION
This allows you to do IO (and therefore do whatever you want) when constructing a `Pandoc` from text or string or whatever. It was necessary for using certain pandoc filters :)

