### PR TITLE
Adding support for org-mode

### DIFF
--- a/src/Slick.hs
+++ b/src/Slick.hs
@@ -17,6 +17,7 @@ module Slick
   , slickWithOpts
   , markdownToHTML
   , markdownToHTML'
+  , orgToHTML
 
   -- ** Mustache Templating
   , compileTemplate'


### PR DESCRIPTION
Hi,

I was frustrated that hakyll did not support metadata for org-mode. Fortunately, I discovered your library, which seems to do the trick nicely as it uses pandoc under the hood !
So I've simply added an `orgToHTML` function to manage posts in org-mode.