### PR TITLE
trivial fix for those who want to use slick with aeson 2

### DIFF
--- a/src/Slick/Pandoc.hs
+++ b/src/Slick/Pandoc.hs
@@ -32,11 +32,11 @@ module Slick.Pandoc
   ) where
 
 import Data.Aeson
+import Data.Aeson.KeyMap as KM
 import Development.Shake
 import Text.Pandoc
 import Text.Pandoc.Highlighting
 import Slick.Utils
-import Data.HashMap.Strict as HM
 
 import qualified Data.Text                  as T
 
@@ -233,7 +233,7 @@ loadUsingMeta reader writer metaWriter text = do
   (pdoc, meta) <- makePandocReaderWithMetaWriter reader metaWriter text
   outText      <- unPandocM $ writer pdoc
   withContent <- case meta of
-      Object m -> return . Object $ HM.insert "content" (String outText) m
+      Object m -> return . Object $ KM.insert "content" (String outText) m
           -- meta & _Object . at "content" ?~ String outText
       _ -> fail "Failed to parse metadata"
   return withContent

--- a/src/Slick/Pandoc.hs
+++ b/src/Slick/Pandoc.hs
@@ -32,7 +32,7 @@ module Slick.Pandoc
   ) where
 
 import Data.Aeson
-import Data.Aeson.KeyMap as KM
+import qualified Data.Aeson.KeyMap as KM
 import Development.Shake
 import Text.Pandoc
 import Text.Pandoc.Highlighting


### PR DESCRIPTION
This is a draft PR, because I did not change the package.json or stack.yaml files. Afaik, there currently is no stack release that uses both ghc 8.10.7 and aeson 2. However, this fix may still be useful for people who use slick without stack. I publish the changes here for improved visibility.